### PR TITLE
Allow connection to fall back to audio-only when video isn't available

### DIFF
--- a/jitsirtc.js
+++ b/jitsirtc.js
@@ -519,7 +519,8 @@ class JitsiRTCClient extends WebRTCInterface {
 			})
 			.then(await this._onLocalTracks.bind(this,resolve))
 			.catch(error => {
-				throw error;
+				this.debug("Failed to initialize stream: ", error);
+				resolve(null);
 			});
 		} else {
 			


### PR DESCRIPTION
When video isn't available either due to the lack of a webcam or because
the user denied video permissions, the initialization of the stream will
fail. If the returned stream is null, FVTT will automatically attempt to
fall back to an audio-only stream.

Returning in this way also allows FVTT to properly display the error to
the user within game.