### PR TITLE
audio: Fix audio-only input

### DIFF
--- a/jitsirtc.js
+++ b/jitsirtc.js
@@ -323,7 +323,7 @@ class JitsiRTCClient extends WebRTCInterface {
  	
     assignStreamToVideo(stream, video) {
 		this.debug("assignStreamToVideo stream:", stream, " video:", video);
-		if ( stream && (stream.getVideoTracks().length > 0) ) {
+		if (stream) {
 	
 			try {
 				video.srcObject = stream;
@@ -712,8 +712,8 @@ Hooks.on("setup", function() {
   WebRTC.prototype.onUserAudioStreamChange = function(userId, stream) {
 	const userSettings = this.settings.users[userId];
 
-	if (!userSettings.canBroadcastAudio) {
-		
+	if (userSettings.canBroadcastAudio) {
+		this.setVideoStream(userId, stream);
 		if (this.streamHasAudio(stream)) {
 		  const audioLevelHandler = this._onAudioLevel.bind(this, userId);
 		  game.audio.startLevelReports(userId, stream, audioLevelHandler, CONFIG.WebRTC.emitVolumeInterval);


### PR DESCRIPTION
assignStreamToVideo should be used to assign a stream to the video
element even if no video tracks exist. The video element is used even
when a stream is audio-only.

Fix reversed logic on canBroadcastAudio check to properly set up the
audio elements. Also always call setVideoStream in case an audio track
is updated without a video track.

Fixes issue #12