### PR TITLE
Add domain variable

### DIFF
--- a/jitsirtc.js
+++ b/jitsirtc.js
@@ -686,11 +686,13 @@ class JitsiRTCClient extends WebRTCInterface {
     if (value) {
       // Initially set to defaults
       const serverUrl = this.settings.serverUrl || JitsiRTCClient.defaultJitsiServer;
+      game.settings.set('jitsirtc', 'domainUrl', `${serverUrl}`);
       game.settings.set('jitsirtc', 'mucUrl', `conference.${serverUrl}`);
       game.settings.set('jitsirtc', 'focusUrl', `focus.${serverUrl}`);
       game.settings.set('jitsirtc', 'boshUrl', `//${serverUrl}/http-bind`);
     } else {
       // Clear values
+      game.settings.set('jitsirtc', 'domainUrl', '');
       game.settings.set('jitsirtc', 'mucUrl', '');
       game.settings.set('jitsirtc', 'focusUrl', '');
       game.settings.set('jitsirtc', 'boshUrl', '');

--- a/jitsirtc.js
+++ b/jitsirtc.js
@@ -138,7 +138,7 @@ class JitsiRTCClient extends WebRTCInterface {
       );
 
       // Set Jitsi URL
-      this.jitsiURL = `https://${options.hosts.domain}/${this._room}`;
+      this.jitsiURL = `https://${connectionOptions.host}/${this._room}`;
 
       // If external users are allowed, add the setting
       if (game.settings.get('jitsirtc', 'allowExternalUsers')) {

--- a/jitsirtc.js
+++ b/jitsirtc.js
@@ -76,11 +76,13 @@ class JitsiRTCClient extends WebRTCInterface {
         auth = {};
       } else {
         // Use custom server config
+        let domaintUrl = `${connectionOptions.host}`;
         let mucUrl = `conference.${connectionOptions.host}`;
         let focusUrl = `focus.${connectionOptions.host}`;
         let boshUrl = `//${connectionOptions.host}/http-bind`;
 
         if (game.settings.get('jitsirtc', 'customUrls')) {
+          domainUrl = game.settings.get('jitsirtc', 'domainUrl');
           mucUrl = game.settings.get('jitsirtc', 'mucUrl');
           focusUrl = game.settings.get('jitsirtc', 'focusUrl');
           boshUrl = game.settings.get('jitsirtc', 'boshUrl');
@@ -88,7 +90,7 @@ class JitsiRTCClient extends WebRTCInterface {
 
         options = {
           hosts: {
-            domain: connectionOptions.host,
+            domain: domainUrl,
             muc: mucUrl,
             focus: focusUrl,
           },
@@ -732,6 +734,16 @@ Hooks.on('init', () => {
     type: Boolean,
     onChange: (value) => game.webrtc.client._useCustomUrls(value),
   });
+  game.settings.register('jitsirtc', 'domainUrl', {
+    name: 'Jitsi Domain URL',
+    hint: 'config["hosts"]["domain"] in jitsi-meet config.js',
+    default: '',
+    scope: 'world',
+    type: String,
+    config: game.settings.get('jitsirtc', 'customUrls'),
+    onChange: () => window.location.reload(),
+  });
+
   game.settings.register('jitsirtc', 'mucUrl', {
     name: 'Jitsi MUC URL',
     hint: 'config["hosts"]["muc"] in jitsi-meet config.js',

--- a/jitsirtc.js
+++ b/jitsirtc.js
@@ -76,7 +76,7 @@ class JitsiRTCClient extends WebRTCInterface {
         auth = {};
       } else {
         // Use custom server config
-        let domaintUrl = `${connectionOptions.host}`;
+        let domainUrl = `${connectionOptions.host}`;
         let mucUrl = `conference.${connectionOptions.host}`;
         let focusUrl = `focus.${connectionOptions.host}`;
         let boshUrl = `//${connectionOptions.host}/http-bind`;


### PR DESCRIPTION
First attempt at this.  Happy to modify.

Have added the domainUrl value that will default to the connectionOptions.host as previous but when you select custom url's it gives you the option of modifying this as for example the docker defaults for jitsi are meet.jitsi not the url of the hosted platform.
