### PR TITLE
Update simulcast and resolution settings for consistent video

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v0.4.17
+* Update simulcast and resolution settings for consistent video
+
 # v0.4.16
 * Add some additional logging around connection states to attempt to track down camera freezing issues
 

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
   "title": "Jitsi WebRTC client",
   "description": "Use Jitsi to handle A/V. Connect to jitsi.org or self-hosted server.",
   "author": "Luvolondon, bekit",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "styles": [],
   "packs": [],
   "url": "https://github.com/luvolondon/fvtt-module-jitsiwebrtc",

--- a/scripts/jitsirtc.js
+++ b/scripts/jitsirtc.js
@@ -580,16 +580,6 @@ class JitsiRTCClient extends AVClient {
         constraints: {
           video: {
             aspectRatio: 4 / 3,
-            height: {
-              ideal: 240,
-              max: 480,
-              min: 120,
-            },
-            width: {
-              ideal: 320,
-              max: 640,
-              min: 160,
-            },
           },
         },
       });
@@ -701,8 +691,9 @@ class JitsiRTCClient extends AVClient {
     // Set our jitsi username to our FVTT user ID
     this._jitsiConference.setDisplayName(game.user.id);
 
-    // Set the preferred resolution of video to send
+    // Set the preferred resolution of video to send and recieve
     this._jitsiConference.setSenderVideoConstraint(240);
+    this._jitsiConference.setReceiverVideoConstraint(240);
 
     // Set up jitsi event handles
     this._jitsiConference.on(
@@ -928,6 +919,10 @@ class JitsiRTCClient extends AVClient {
     this._usernameCache[displayName] = id;
     this._participantCache[displayName] = participant;
     this._idCache[id] = displayName;
+
+    // Select all participants so their video stays active
+    this._jitsiConference.selectParticipants(Object.keys(game.webrtc.client._idCache));
+
     this.debug("User joined:", displayName);
 
     this._render();
@@ -1118,9 +1113,6 @@ class JitsiRTCClient extends AVClient {
     config.enableP2P = false;
     config.p2p.enabled = false;
 
-    // Disable simulcast for performance
-    config.disableSimulcast = true;
-
     // Disable audio detections for performance
     config.enableNoAudioDetection = false;
     config.enableNoisyMicDetection = false;
@@ -1130,8 +1122,6 @@ class JitsiRTCClient extends AVClient {
     config.audioLevelsInterval = 500;
 
     // Configure settings for consistant video
-    config.enableLayerSuspension = false;
-    config.disableSuspendVideo = true;
     config.channelLastN = -1;
     config.adaptiveLastN = false;
     delete config.lastNLimits;


### PR DESCRIPTION
Having simulcast disabled causes chrome to freeze the video much more
often in cases where the server thinks bandwidth is limited. Having
simulcast available lets the stream resolution/framerate lower instead
of freezing completely.

Remove specific video resolution constraints and instead use
setSenderVideoConstraint and setReceiverVideoConstraint to specify the
requested resolution.

Use JitsiConference.selectParticipants to tell the server that we are
viewing all connected users to reduce the chance that it will freeze
the video.

ref: #54 